### PR TITLE
Update MardiEntities.py

### DIFF
--- a/mardiclient/MardiEntities.py
+++ b/mardiclient/MardiEntities.py
@@ -17,7 +17,8 @@ class MardiItem(ItemEntity):
             entity = super().write(**kwargs)
             return entity
         except ModificationFailed as e:
-            return self.handleModificationFailed(e)
+            self.handleModificationFailed(e)
+            raise
 
     def handleModificationFailed(self, e):
         """Handle ModificationFailed Exception


### PR DESCRIPTION
Before this change, if a write failed, the error was only printed, but not returned. The expected behavior is for the error to be thrown. How it was implemented before leads to errors being overlooked.